### PR TITLE
Технічне: використання python:3.12-slim базового імеджа для svg_gererator

### DIFF
--- a/deploy/svg_generator/Dockerfile
+++ b/deploy/svg_generator/Dockerfile
@@ -1,3 +1,9 @@
+# FROM python:3.12-slim
+# COPY svg_generator.py .
+# RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \
+#     apt-get update && apt-get install -y libcairo2 && apt-get clean &&\
+#     python -m pip install --no-cache-dir -r /tmp/requirements.txt
+# CMD python svg_generator.py
 FROM python:3.12-bullseye
 COPY svg_generator.py .
 RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \

--- a/deploy/svg_generator/Dockerfile
+++ b/deploy/svg_generator/Dockerfile
@@ -1,11 +1,7 @@
-# FROM python:3.12-slim
-# COPY svg_generator.py .
-# RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \
-#     apt-get update && apt-get install -y libcairo2 && apt-get clean &&\
-#     python -m pip install --no-cache-dir -r /tmp/requirements.txt
-# CMD python svg_generator.py
-FROM python:3.12-bullseye
+FROM python:3.12-slim
 COPY svg_generator.py .
 RUN --mount=type=bind,source=requirements.txt,target=/tmp/requirements.txt \
+    apt-get update && apt-get install --no-install-recommends -y libcairo2 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     python -m pip install --no-cache-dir -r /tmp/requirements.txt
 CMD python svg_generator.py


### PR DESCRIPTION
При тесуванні PR #187 було виявленно, що [svg_generator.py](https://github.com/J-A-A-M/ukraine_alarm_map/blob/master/deploy/svg_generator/svg_generator.py) падає при використанні базового імеджа `python:3.12-slim` (чи іншого slim-образа). Для того, щоб вмерджити PR @v00g100skr замінив імедж на python:3.12-bullseye, а цей PR фактично є фіксом, що виправляє роботу `svg_generator.py` з slim імеджем.

Причиною є відпустність бібліотеки `libcairo2`, що потрібна для пакету [cairosvg](https://github.com/Kozea/CairoSVG/):

```
docker run -it --rm python:3.12-slim bash
root@e60baa3d93aa:/# pip install cairosvg==2.7.1
Collecting cairosvg==2.7.1
  Downloading CairoSVG-2.7.1-py3-none-any.whl.metadata (2.7 kB)
Collecting cairocffi (from cairosvg==2.7.1)
  Downloading cairocffi-1.6.1-py3-none-any.whl.metadata (3.3 kB)
Collecting cssselect2 (from cairosvg==2.7.1)
  Downloading cssselect2-0.7.0-py3-none-any.whl.metadata (2.9 kB)
Collecting defusedxml (from cairosvg==2.7.1)
  Downloading defusedxml-0.7.1-py2.py3-none-any.whl.metadata (32 kB)
Collecting pillow (from cairosvg==2.7.1)
  Downloading pillow-10.3.0-cp312-cp312-manylinux_2_28_x86_64.whl.metadata (9.2 kB)
Collecting tinycss2 (from cairosvg==2.7.1)
  Downloading tinycss2-1.2.1-py3-none-any.whl.metadata (3.0 kB)
Collecting cffi>=1.1.0 (from cairocffi->cairosvg==2.7.1)
  Downloading cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.5 kB)
Collecting webencodings (from cssselect2->cairosvg==2.7.1)
  Downloading webencodings-0.5.1-py2.py3-none-any.whl.metadata (2.1 kB)
Collecting pycparser (from cffi>=1.1.0->cairocffi->cairosvg==2.7.1)
  Downloading pycparser-2.22-py3-none-any.whl.metadata (943 bytes)
Downloading CairoSVG-2.7.1-py3-none-any.whl (43 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 43.2/43.2 kB 1.1 MB/s eta 0:00:00
Downloading cairocffi-1.6.1-py3-none-any.whl (75 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 75.1/75.1 kB 2.2 MB/s eta 0:00:00
Downloading cssselect2-0.7.0-py3-none-any.whl (15 kB)
Downloading defusedxml-0.7.1-py2.py3-none-any.whl (25 kB)
Downloading pillow-10.3.0-cp312-cp312-manylinux_2_28_x86_64.whl (4.5 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.5/4.5 MB 45.5 MB/s eta 0:00:00
Downloading tinycss2-1.2.1-py3-none-any.whl (21 kB)
Downloading cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (477 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 477.6/477.6 kB 12.3 MB/s eta 0:00:00
Downloading webencodings-0.5.1-py2.py3-none-any.whl (11 kB)
Downloading pycparser-2.22-py3-none-any.whl (117 kB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 117.6/117.6 kB 3.3 MB/s eta 0:00:00
Installing collected packages: webencodings, tinycss2, pycparser, pillow, defusedxml, cssselect2, cffi, cairocffi, cairosvg
Successfully installed cairocffi-1.6.1 cairosvg-2.7.1 cffi-1.16.0 cssselect2-0.7.0 defusedxml-0.7.1 pillow-10.3.0 pycparser-2.22 tinycss2-1.2.1 webencodings-0.5.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
root@e60baa3d93aa:/# python -c "import cairosvg"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.12/site-packages/cairosvg/__init__.py", line 26, in <module>
    from . import surface  # noqa isort:skip
    ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cairosvg/surface.py", line 9, in <module>
    import cairocffi as cairo
  File "/usr/local/lib/python3.12/site-packages/cairocffi/__init__.py", line 47, in <module>
    cairo = dlopen(
            ^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cairocffi/__init__.py", line 44, in dlopen
    raise OSError(error_message)  # pragma: no cover
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: no library called "cairo-2" was found
no library called "cairo" was found
no library called "libcairo-2" was found
cannot load library 'libcairo.so.2': libcairo.so.2: cannot open shared object file: No such file or directory.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'libcairo.so.2'
cannot load library 'libcairo.2.dylib': libcairo.2.dylib: cannot open shared object file: No such file or directory.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'libcairo.2.dylib'
cannot load library 'libcairo-2.dll': libcairo-2.dll: cannot open shared object file: No such file or directory.  Additionally, ctypes.util.find_library() did not manage to locate a library called 'libcairo-2.dll'
root@e60baa3d93aa:/# 
```

Рішенням є поставити пакет `libcairo2`

Тесувалось на [тестовому SVG](https://filesamples.com/samples/image/svg/sample_1280%C3%97853.svg) за допомогою консольної `cairosvg`

Результат +13MB за рахунок `libcairo.2` та залежностей, але все одно, імедж майже впятеро менший:
```
$ docker images
REPOSITORY                  TAG             IMAGE ID       CREATED             SIZE
svg                         3.12-slim       0c3f213ffb54   9 seconds ago       174MB
svg                         3.12-bullseye   45ff6c29e26c   53 minutes ago      963MB
```
