### PR TITLE
технічне: оновлення залежностей (bump aiohttp from 3.9.3 to 3.9.4) на конфігурування dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,8 +2,16 @@
 
 version: 2
 updates:
+  # Enable version updates for pip dependencies
   - package-ecosystem: "pip"
     directory: "/deploy/"
+    schedule:
+      interval: "weekly"
+    target:
+      branch: "develop"
+
+  # Enable version updates for github actions
+  - package-ecosystem: "github-actions"
     schedule:
       interval: "weekly"
     target:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Configure dependabot to check dependency weekly and make dependency update to `develop` branch
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/deploy/"
+    schedule:
+      interval: "weekly"
+    target:
+      branch: "develop"

--- a/deploy/alerts/requirements.txt
+++ b/deploy/alerts/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==3.9.3
+aiohttp==3.9.4
 aiomcache==0.8.1

--- a/deploy/check/requirements.txt
+++ b/deploy/check/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==3.9.3
+aiohttp==3.9.4
 aiomcache==0.8.1

--- a/deploy/etryvoga/requirements.txt
+++ b/deploy/etryvoga/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==3.9.3
+aiohttp==3.9.4
 aiomcache==0.8.1

--- a/deploy/weather/requirements.txt
+++ b/deploy/weather/requirements.txt
@@ -1,2 +1,2 @@
-aiohttp==3.9.3
+aiohttp==3.9.4
 aiomcache==0.8.1


### PR DESCRIPTION
##### SUMMARY
Поточно dependabot робить PR-и у бранч `main` попри те, що розробка та тестування ведеться у бранчі `develop`, зручніше, коли коміти будуть безпосередньо у `develop`

##### ISSUE TYPE
Технічне/CI

##### COMPONENT NAME
dependabot

##### ADDITIONAL INFORMATION
Цей PR включає у себе бекпорт #200, #201, #202 та #203 у `develop`, а також конфігурацію dependabot для того, щоб наступні апліфти pip-залежностей відбувались у бранч `develop` щотижнево.