### PR TITLE
Update ha_mqttpassword length in JaamFirmware.cpp

### DIFF
--- a/firmware/src/JaamFirmware.cpp
+++ b/firmware/src/JaamFirmware.cpp
@@ -61,7 +61,7 @@ struct Settings {
   int     lightpin               = 32;
   int     ha_mqttport            = 1883;
   char    ha_mqttuser[31]        = "";
-  char    ha_mqttpassword[51]    = "";
+  char    ha_mqttpassword[65]    = "";
   char    ha_brokeraddress[31]   = "";
   int     current_brightness     = 50;
   int     brightness             = 50;
@@ -2027,7 +2027,7 @@ void handleDev(AsyncWebServerRequest* request) {
     addInputText(response, "ha_brokeraddress", "Адреса mqtt Home Assistant", "text", settings.ha_brokeraddress, 30);
     addInputText(response, "ha_mqttport", "Порт mqtt Home Assistant", "number", String(settings.ha_mqttport).c_str());
     addInputText(response, "ha_mqttuser", "Користувач mqtt Home Assistant", "text", settings.ha_mqttuser, 30);
-    addInputText(response, "ha_mqttpassword", "Пароль mqtt Home Assistant", "text", settings.ha_mqttpassword, 50);
+    addInputText(response, "ha_mqttpassword", "Пароль mqtt Home Assistant", "text", settings.ha_mqttpassword, 64);
   }
   addInputText(response, "ntphost", "Адреса сервера NTP", "text", settings.ntphost, 30);
   addInputText(response, "serverhost", "Адреса сервера даних", "text", settings.serverhost, 30);


### PR DESCRIPTION
This pull request includes changes to the `firmware/src/JaamFirmware.cpp` file to increase the length of the MQTT password field. The most important changes are as follows:

### Changes to MQTT password handling:

* Increased the size of the `ha_mqttpassword` field from 51 to 65 characters in the `Settings` structure. (`firmware/src/JaamFirmware.cpp`)
* Updated the `handleDev` function to reflect the new length of the `ha_mqttpassword` field in the input text. (`firmware/src/JaamFirmware.cpp`)

## Про зміни
Збільшення дозволеної довжини пароля [запит з Телеграм чату](https://t.me/jaam_discussions/1220).