### PR TITLE
Технічне: генерація release_notes.json/release_notes_beta.json

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -39,11 +39,33 @@ jobs:
       #     cd ${{ github.workspace }}/bin_beta/
       #     ls -tp | grep -v '/$' | tail -n +5 | xargs -I {} rm -- {}
       #     cd ${{ github.workspace }}
+      - name: Create Beta Pre Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: ${{ github.workspace }}/JAAM_${{ env.BETA_VERSION }}.bin
+          name: ${{ env.RELEASE_TITLE }}
+          commit: ${{ steps.commit_changes.outputs.commit_hash }}
+          tag: ${{ env.BETA_VERSION }}
+          generateReleaseNotes: true
+          allowUpdates: true
+          prerelease: true
+          makeLatest: false
       - name: Fetch release notes
         run: |
           RELEASE_NOTES=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.BETA_VERSION }} | jq -r '.body' | sed '/^$/d')
           echo "$RELEASE_NOTES" > ${{ github.workspace }}/flasher/release_notes_beta.txt
           echo "{\"version\": \"${{ env.BETA_VERSION }}\", \"releasenote\": \"${RELEASENOTES}\"}" > ${{ github.workspace }}/flasher/release_notes_beta.json
+      - name: Copy release notes to bin folder
+        run: |
+          mkdir -p ${{ github.workspace }}/bin_beta/
+          if [ -f ${{ github.workspace }}/flasher/release_notes_beta.txt ]; then
+            cp -f ${{ github.workspace }}/flasher/release_notes_beta.txt ${{ github.workspace }}/bin_beta/${{ env.BETA_VERSION }}.txt
+            cp -f ${{ github.workspace }}/flasher/release_notes_beta.txt ${{ github.workspace }}/bin_beta/latest_beta.txt
+          fi
+          if [ -f ${{ github.workspace }}/flasher/release_notes_beta.json ]; then
+            cp -f ${{ github.workspace }}/flasher/release_notes_beta.json ${{ github.workspace }}/bin_beta/${{ env.BETA_VERSION }}.txt
+            cp -f ${{ github.workspace }}/flasher/release_notes_beta.json ${{ github.workspace }}/bin_beta/latest_beta.json
+          fi
       - name: Upload flasher to Github Pages
         uses: ./.github/workflows/upload-pages
         with:
@@ -56,17 +78,6 @@ jobs:
         with:
           commit_message: "Beta ${{ env.BETA_VERSION }}"
           file_pattern: ${{ github.workspace }}/bin_beta/ ${{ github.workspace }}/flasher/
-      - name: Create Beta Pre Release
-        uses: ncipollo/release-action@v1
-        with:
-          artifacts: ${{ github.workspace }}/JAAM_${{ env.BETA_VERSION }}.bin
-          name: ${{ env.RELEASE_TITLE }}
-          commit: ${{ steps.commit_changes.outputs.commit_hash }}
-          tag: ${{ env.BETA_VERSION }}
-          generateReleaseNotes: true
-          allowUpdates: true
-          prerelease: true
-          makeLatest: false
       - name: Update server test bin list
         uses: appleboy/ssh-action@v1.2.0
         with:

--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -39,12 +39,17 @@ jobs:
       #     cd ${{ github.workspace }}/bin_beta/
       #     ls -tp | grep -v '/$' | tail -n +5 | xargs -I {} rm -- {}
       #     cd ${{ github.workspace }}
+      - name: Fetch release notes
+        run: |
+          RELEASE_NOTES=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ env.BETA_VERSION }} | jq -r '.body' | sed '/^$/d')
+          echo "$RELEASE_NOTES" > ${{ github.workspace }}/flasher/release_notes_beta.txt
+          echo "{\"version\": \"${{ env.BETA_VERSION }}\", \"releasenote\": \"${RELEASENOTES}\"}" > ${{ github.workspace }}/flasher/release_notes_beta.json
       - name: Upload flasher to Github Pages
         uses: ./.github/workflows/upload-pages
         with:
           beta_binary_path: ${{ github.workspace }}/JAAM_${{ env.BETA_VERSION }}.bin
           version: ${{ inputs.release-version }}
-          beta_build: ${{ github.run_number }}  
+          beta_build: ${{ github.run_number }}
       - name: Commit changes
         id: commit_changes
         uses: stefanzweifel/git-auto-commit-action@v5
@@ -61,7 +66,7 @@ jobs:
           generateReleaseNotes: true
           allowUpdates: true
           prerelease: true
-          makeLatest: false    
+          makeLatest: false
       - name: Update server test bin list
         uses: appleboy/ssh-action@v1.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,12 +90,6 @@ jobs:
       #     cd ${{ github.workspace }}/bin_beta/
       #     ls -tp | grep -v '/$' | tail -n +5 | xargs -I {} rm -- {}
       #     cd ${{ github.workspace }}
-      - name: Upload flasher to Github Pages
-        uses: ./.github/workflows/upload-pages
-        with:
-          binary_path: ${{ github.workspace }}/JAAM_${{ inputs.release-version }}.bin/JAAM_${{ inputs.release-version }}.bin
-          lite_binary_path: ${{ github.workspace }}/JAAM_${{ inputs.release-version }}_lite.bin/JAAM_${{ inputs.release-version }}_lite.bin
-          version: ${{ inputs.release-version }}
       - name: Commit changes
         id: commit_changes
         uses: stefanzweifel/git-auto-commit-action@v5
@@ -112,6 +106,17 @@ jobs:
           generateReleaseNotes: true
           allowUpdates: true
           makeLatest: true
+      - name: Fetch release notes
+        run: |
+          RELEASE_NOTES=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ inputs.release-version }} | jq -r '.body' | sed '/^$/d')
+          echo "$RELEASE_NOTES" > ${{ github.workspace }}/flasher/release_notes.txt
+          echo "{\"version\": \"${{ inputs.release-version }}\", \"releasenote\": \"${RELEASENOTES}\"}" > ${{ github.workspace }}/flasher/release_notes.json
+      - name: Upload flasher to Github Pages
+        uses: ./.github/workflows/upload-pages
+        with:
+          binary_path: ${{ github.workspace }}/JAAM_${{ inputs.release-version }}.bin/JAAM_${{ inputs.release-version }}.bin
+          lite_binary_path: ${{ github.workspace }}/JAAM_${{ inputs.release-version }}_lite.bin/JAAM_${{ inputs.release-version }}_lite.bin
+          version: ${{ inputs.release-version }}
       - name: Merge master -> develop
         uses: devmasx/merge-branch@master
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,12 +90,6 @@ jobs:
       #     cd ${{ github.workspace }}/bin_beta/
       #     ls -tp | grep -v '/$' | tail -n +5 | xargs -I {} rm -- {}
       #     cd ${{ github.workspace }}
-      - name: Commit changes
-        id: commit_changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "Release ${{ inputs.release-version }}"
-          file_pattern: ${{ github.workspace }}/firmware/src/JaamFirmware.cpp ${{ github.workspace }}/bin/ ${{ github.workspace }}/bin_beta/ ${{ github.workspace }}/flasher/
       - name: Create Release
         uses: ncipollo/release-action@v1
         with:
@@ -111,6 +105,22 @@ jobs:
           RELEASE_NOTES=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ inputs.release-version }} | jq -r '.body' | sed '/^$/d')
           echo "$RELEASE_NOTES" > ${{ github.workspace }}/flasher/release_notes.txt
           echo "{\"version\": \"${{ inputs.release-version }}\", \"releasenote\": \"${RELEASENOTES}\"}" > ${{ github.workspace }}/flasher/release_notes.json
+      - name: Copy release notes to bin folder
+        run: |
+          mkdir -p ${{ github.workspace }}/bin_beta/
+          if [ -f ${{ github.workspace }}/flasher/release_notes.txt ]; then
+            cp -f ${{ github.workspace }}/flasher/release_notes.txt ${{ github.workspace }}/bin/${{ inputs.release-version }}.txt
+            cp -f ${{ github.workspace }}/flasher/release_notes.txt ${{ github.workspace }}/bin/latest.txt
+          fi
+          if [ -f ${{ github.workspace }}/flasher/release_notes.json ]; then
+            cp -f ${{ github.workspace }}/flasher/release_notes.json ${{ github.workspace }}/bin/latest.json
+          fi
+      - name: Commit changes
+        id: commit_changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Release ${{ inputs.release-version }}"
+          file_pattern: ${{ github.workspace }}/firmware/src/JaamFirmware.cpp ${{ github.workspace }}/bin/ ${{ github.workspace }}/bin_beta/ ${{ github.workspace }}/flasher/
       - name: Upload flasher to Github Pages
         uses: ./.github/workflows/upload-pages
         with:


### PR DESCRIPTION
Як перша таска з декомпозиції #261 пропоную генерувати JSON та/чи TXT файли і викадати їх поруч із файлом прошивки на https://flasher.jaam.net.ua/

Мінімалістичний контент і уніфіковані імена (`release_notes.json` та `release_notes_beta.json` для відповідних каналів оновлення) дозволять доволі легко читати їх силами ESP32 для подальшого відображення у WEB-UI.