### PR TITLE
Технічне: невелика реорганізація CI

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,4 +1,4 @@
-  name: 🏗️ Compile Firmware + Lint Check
+  name: 🏗️ Compile Firmware
   on:
     pull_request:
       types: [ opened, synchronize, reopened ]
@@ -85,22 +85,3 @@
           with:
             name: updater.bin
             path: ${{ github.workspace }}/updater.bin
-    check_flasher:
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v4
-          - name: Check flasher with proof-html
-            uses: anishathalye/proof-html@v2
-            with:
-              directory: ${{ github.workspace }}/flasher
-    run_black:
-        runs-on: ubuntu-latest
-        steps:
-          - uses: actions/checkout@v4
-          - name: Run Black in the check mode
-            uses: psf/black@stable
-            with:
-              options: "--check --verbose --line-length 120 --diff --color --target-version py312"
-              src: ${{ github.workspace }}/deploy
-              version: "~= 24.0"
-

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,28 @@
+name: 🧹 Lint Check
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    branches:
+      - develop
+jobs:
+  check_flasher:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - name: Check flasher with proof-html
+          uses: anishathalye/proof-html@v2
+          with:
+            directory: ${{ github.workspace }}/flasher
+  run_black:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - name: Run Black in the check mode
+          uses: psf/black@stable
+          with:
+            options: "--check --verbose --line-length 120 --diff --color --target-version py312"
+            src: ${{ github.workspace }}/deploy
+            version: "~= 24.0"


### PR DESCRIPTION
Невелика реорганізація CI, а саме винесення лінтерів (black, proof-html) у окрему action та включення лінтерів для прямого пушу у бранч `develop`.

Причина: зараз лінтери раняться лише для PR-ів, в результаті при прямому пуші у бранч `develop` можна отримати несподівані результати.

Цей PR повторює #269

It's squashed commit of:
abe0e8b67f2e36388fb9781fdfb7624c1cd0d109
df3edcf3866d92f36c4f1fa34fcfac6ce2087dd0