### PR TITLE
docs: Clarify link destination in JAAM Web UI

### DIFF
--- a/firmware/src/JaamFirmware.cpp
+++ b/firmware/src/JaamFirmware.cpp
@@ -2199,7 +2199,7 @@ void handleBrightness(AsyncWebServerRequest* request) {
   if (lightSensor.isAnySensorAvailable()) {
     addSlider(response, "light_sensor_factor", "Коефіцієнт чутливості сенсора освітлення", settings.light_sensor_factor, 0.1f, 30.0f, 0.1f);
   }
-  response->println("<p class='text-info'>Детальніше про сенсор освітлення на <a href='https://github.com/v00g100skr/ukraine_alarm_map/wiki/%D0%A1%D0%B5%D0%BD%D1%81%D0%BE%D1%80-%D0%BE%D1%81%D0%B2%D1%96%D1%82%D0%BB%D0%B5%D0%BD%D0%BD%D1%8F'>Wiki</a>.</p>");
+  response->println("<p class='text-info'>Детальніше про сенсор освітлення на <a href='https://github.com/J-A-A-M/ukraine_alarm_map/wiki/%D0%A1%D0%B5%D0%BD%D1%81%D0%BE%D1%80-%D0%BE%D1%81%D0%B2%D1%96%D1%82%D0%BB%D0%B5%D0%BD%D0%BD%D1%8F'>Wiki</a>.</p>");
   response->println("<button type='submit' class='btn btn-info'>Зберегти налаштування</button>");
   response->println("</div>");
   response->println("</div>");

--- a/firmware/src/JaamFirmware.cpp
+++ b/firmware/src/JaamFirmware.cpp
@@ -2199,7 +2199,7 @@ void handleBrightness(AsyncWebServerRequest* request) {
   if (lightSensor.isAnySensorAvailable()) {
     addSlider(response, "light_sensor_factor", "Коефіцієнт чутливості сенсора освітлення", settings.light_sensor_factor, 0.1f, 30.0f, 0.1f);
   }
-  response->println("<p class='text-info'>Детальніше на <a href='https://github.com/v00g100skr/ukraine_alarm_map/wiki/%D0%A1%D0%B5%D0%BD%D1%81%D0%BE%D1%80-%D0%BE%D1%81%D0%B2%D1%96%D1%82%D0%BB%D0%B5%D0%BD%D0%BD%D1%8F'>Wiki</a>.</p>");
+  response->println("<p class='text-info'>Детальніше про сенсор освітлення на <a href='https://github.com/v00g100skr/ukraine_alarm_map/wiki/%D0%A1%D0%B5%D0%BD%D1%81%D0%BE%D1%80-%D0%BE%D1%81%D0%B2%D1%96%D1%82%D0%BB%D0%B5%D0%BD%D0%BD%D1%8F'>Wiki</a>.</p>");
   response->println("<button type='submit' class='btn btn-info'>Зберегти налаштування</button>");
   response->println("</div>");
   response->println("</div>");


### PR DESCRIPTION
## Проблема
Наразі існує наступне посилання:

![IMG_20250112_101436_029](https://github.com/user-attachments/assets/3baf374e-7343-437c-8839-055a91fba338)

Воно йде на одному рівні з усіма налаштуваннями, після налаштувань. Це призводить до двочитання

## Рішення
Для уникнення непорозумінь, варто:
* зробити відступ, щоб інформація про Вікі була підпунктом до налаштувань сенсора освітлення  
або
* уточнити посилання

Цей ПР йде другим шляхом - уточнює посилання