### PR TITLE
Fix: Виправлено початкове значення коефіцієнта чутливості

### DIFF
--- a/firmware/src/JaamSettings.cpp
+++ b/firmware/src/JaamSettings.cpp
@@ -147,7 +147,7 @@ std::map<Type, SettingItemFloat> floatSettings = {
     {TEMP_CORRECTION, {"ltc", 0.0f}},
     {HUM_CORRECTION, {"lhc", 0.0f}},
     {PRESSURE_CORRECTION, {"lpc", 0.0f}},
-    {LIGHT_SENSOR_FACTOR, {"lsf", 0.0f}},
+    {LIGHT_SENSOR_FACTOR, {"lsf", 1.0f}},
 };
 
 Preferences preferences;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Оновлено налаштування сенсора освітленості: стандартний коефіцієнт було скориговано для підвищення точності вимірювань. Це оновлення спрямоване на забезпечення кращої продуктивності та точності даних, що безпосередньо покращує досвід використання пристрою в різних умовах експлуатації.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->