### PR TITLE
Рефакторінг: залежності відображення сповіщень, статусів і тривог

### DIFF
--- a/deploy/tests/test_update_drones_etryvoga_v1.py
+++ b/deploy/tests/test_update_drones_etryvoga_v1.py
@@ -22,8 +22,7 @@ async def test_1():
     """
 
     mock_mc = AsyncMock(spec=Client)
-    mock_mc.set.return_value = True 
-
+    mock_mc.set.return_value = True
 
     def mock_get_cache_data_side_effect(mc, key, default=None):
         mock_responses = {
@@ -48,7 +47,6 @@ async def test_1():
         expected_result[2] = 1736935200
 
         mock_mc.set.assert_awaited_with(b"drones_websocket_v1", json.dumps(expected_result).encode("utf-8"))
-
 
 
 @pytest.mark.asyncio
@@ -98,6 +96,7 @@ async def test_3():
     mock_mc.set.return_value = True
 
     for _, region in regions.items():
+
         def mock_get_cache_data_side_effect(mc, key, default=None):
             mock_responses = {
                 b"drones_etryvoga": {
@@ -131,8 +130,7 @@ async def test_4():
     """
 
     mock_mc = AsyncMock(spec=Client)
-    mock_mc.set.return_value = True 
-
+    mock_mc.set.return_value = True
 
     def mock_get_cache_data_side_effect(mc, key, default=None):
         drones_websocket_v2 = [[0, 1645674000]] * 26
@@ -154,7 +152,7 @@ async def test_4():
     mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
 
     with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
-        
+
         expected_result = [1700000000] * 26
         expected_result[2] = 1739613600
 
@@ -172,8 +170,7 @@ async def test_5():
     """
 
     mock_mc = AsyncMock(spec=Client)
-    mock_mc.set.return_value = True 
-
+    mock_mc.set.return_value = True
 
     def mock_get_cache_data_side_effect(mc, key, default=None):
         drones_websocket_v2 = [[0, 1645674000]] * 26

--- a/deploy/tests/test_update_drones_etryvoga_v1.py
+++ b/deploy/tests/test_update_drones_etryvoga_v1.py
@@ -15,38 +15,45 @@ unix 1736935200 - 2025-01-15T10:00:00Z
 
 @pytest.mark.asyncio
 @patch("updater.updater.update_period", new=0)
-@patch("updater.updater.get_cache_data", new_callable=AsyncMock)
-@patch("updater.updater.get_etryvoga", new_callable=AsyncMock)
-async def test_1(mock_get_etryvoga, mock_get_cache_data):
+async def test_1():
     """
     нема даних для вебсокета в мемкеш
     зберігання першої тривоги
     """
 
     mock_mc = AsyncMock(spec=Client)
-    mock_mc.set.return_value = True
+    mock_mc.set.return_value = True 
 
-    mock_get_etryvoga.return_value = {
-        "version": 1,
-        "states": {"11": {"lastUpdate": "2022-02-24T03:40:00Z"}, "21": {"lastUpdate": "2025-01-15T10:00:00Z"}},
-        "info": {
-            "last_update": "2025-01-26T19:18:55Z",
-            "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
-        },
-    }
-    mock_get_cache_data.return_value = []
 
-    await update_drones_etryvoga_v1(mock_mc, run_once=True)
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"drones_etryvoga": {
+                "version": 1,
+                "states": {"11": {"lastUpdate": "2022-02-24T03:40:00Z"}, "21": {"lastUpdate": "2025-01-15T10:00:00Z"}},
+                "info": {
+                    "last_update": "2025-01-26T19:18:55Z",
+                    "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+                },
+            },
+            b"drones_websocket_v2": [[0, 1645674000]] * 26,
+        }
+        return mock_responses.get(key, default)
 
-    expected_result = [1645674000, 0, 1736935200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    mock_mc.set.assert_awaited_with(b"drones_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_drones_etryvoga_v1(mock_mc, run_once=True)
+
+        expected_result = [1645674000] * 26
+        expected_result[2] = 1736935200
+
+        mock_mc.set.assert_awaited_with(b"drones_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+
 
 
 @pytest.mark.asyncio
 @patch("updater.updater.update_period", new=0)
-@patch("updater.updater.get_cache_data", new_callable=AsyncMock)
-@patch("updater.updater.get_etryvoga", new_callable=AsyncMock)
-async def test_2(mock_get_etryvoga, mock_get_cache_data):
+async def test_2():
     """
     є дані в memcache
     апдейт часу першої тривоги
@@ -55,54 +62,34 @@ async def test_2(mock_get_etryvoga, mock_get_cache_data):
     mock_mc = AsyncMock(spec=Client)
     mock_mc.set.return_value = True
 
-    mock_get_etryvoga.return_value = {
-        "version": 1,
-        "states": {"11": {"lastUpdate": "2025-01-15T10:00:00Z"}},
-        "info": {
-            "last_update": "2025-01-26T19:18:55Z",
-            "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
-        },
-    }
-    mock_get_cache_data.return_value = [
-        1645674000,
-        0,
-        1736935200,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ]
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"drones_etryvoga": {
+                "version": 1,
+                "states": {"11": {"lastUpdate": "2025-01-15T10:00:00Z"}},
+                "info": {
+                    "last_update": "2025-01-26T19:18:55Z",
+                    "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+                },
+            },
+            b"drones_websocket_v2": [[0, 1645674000]] * 26,
+        }
+        return mock_responses.get(key, default)
 
-    await update_drones_etryvoga_v1(mock_mc, run_once=True)
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
 
-    expected_result = [1736935200, 0, 1736935200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    mock_mc.set.assert_awaited_with(b"drones_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_drones_etryvoga_v1(mock_mc, run_once=True)
+
+        expected_result = [1645674000] * 26
+        expected_result[0] = 1736935200
+
+        mock_mc.set.assert_awaited_with(b"drones_websocket_v1", json.dumps(expected_result).encode("utf-8"))
 
 
 @pytest.mark.asyncio
 @patch("updater.updater.update_period", new=0)
-@patch("updater.updater.get_cache_data", new_callable=AsyncMock)
-@patch("updater.updater.get_etryvoga", new_callable=AsyncMock)
-async def test_3(mock_get_etryvoga, mock_get_cache_data):
+async def test_3():
     """
     перевірка мапінга
     """
@@ -110,18 +97,106 @@ async def test_3(mock_get_etryvoga, mock_get_cache_data):
     mock_mc = AsyncMock(spec=Client)
     mock_mc.set.return_value = True
 
-    for region_name, region in regions.items():
-        mock_get_etryvoga.return_value = {
-            "version": 1,
-            "states": {str(region["id"]): {"lastUpdate": "2025-01-15T10:00:00Z"}},
-            "info": {
-                "last_update": "2025-01-26T19:18:55Z",
-                "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+    for _, region in regions.items():
+        def mock_get_cache_data_side_effect(mc, key, default=None):
+            mock_responses = {
+                b"drones_etryvoga": {
+                    "version": 1,
+                    "states": {str(region["id"]): {"lastUpdate": "2025-01-15T10:00:00Z"}},
+                    "info": {
+                        "last_update": "2025-01-26T19:18:55Z",
+                        "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+                    },
+                },
+                b"drones_websocket_v2": [[0, 1645674000]] * 26,
+            }
+            return mock_responses.get(key, default)
+
+        mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+        with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+            expected_result = [1645674000] * 26
+            expected_result[region["legacy_id"] - 1] = 1736935200
+
+            await update_drones_etryvoga_v1(mock_mc, run_once=True)
+
+            mock_mc.set.assert_awaited_with(b"drones_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period", new=0)
+async def test_4():
+    """
+    є дані в мемкеші
+    зберігання оновлення там , де нема основної тривоги (21)
+    """
+
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True 
+
+
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        drones_websocket_v2 = [[0, 1645674000]] * 26
+        drones_websocket_v2[0] = [1, 1645674000]
+        mock_responses = {
+            b"drones_etryvoga": {
+                "version": 1,
+                "states": {"11": {"lastUpdate": "2025-02-24T03:40:00Z"}, "21": {"lastUpdate": "2025-02-15T10:00:00Z"}},
+                "info": {
+                    "last_update": "2025-01-26T19:18:55Z",
+                    "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+                },
             },
+            b"drones_websocket_v1": [1700000000] * 26,
+            b"drones_websocket_v2": drones_websocket_v2,
         }
-        expected_result = [0] * 26
-        expected_result[region["legacy_id"] - 1] = 1736935200
+        return mock_responses.get(key, default)
+
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        
+        expected_result = [1700000000] * 26
+        expected_result[2] = 1739613600
 
         await update_drones_etryvoga_v1(mock_mc, run_once=True)
 
         mock_mc.set.assert_awaited_with(b"drones_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period", new=0)
+async def test_5():
+    """
+    є дані в мемкеші
+    нема заберігання, бо всюди тривога
+    """
+
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True 
+
+
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        drones_websocket_v2 = [[0, 1645674000]] * 26
+        drones_websocket_v2[0] = [1, 1645674000]
+        drones_websocket_v2[2] = [1, 1645674000]
+        mock_responses = {
+            b"drones_etryvoga": {
+                "version": 1,
+                "states": {"11": {"lastUpdate": "2025-02-24T03:40:00Z"}, "21": {"lastUpdate": "2025-02-15T10:00:00Z"}},
+                "info": {
+                    "last_update": "2025-01-26T19:18:55Z",
+                    "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+                },
+            },
+            b"drones_websocket_v1": [1700000000] * 26,
+            b"drones_websocket_v2": drones_websocket_v2,
+        }
+        return mock_responses.get(key, default)
+
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+
+        await update_drones_etryvoga_v1(mock_mc, run_once=True)
+
+        mock_mc.set.assert_not_called()

--- a/deploy/tests/test_update_drones_websocket_v2.py
+++ b/deploy/tests/test_update_drones_websocket_v2.py
@@ -241,7 +241,6 @@ async def test_6():
     mock_timestamp = 1700000000
     mock_get_current_timestamp = Mock(return_value=mock_timestamp)
 
-
     with (
         patch("updater.updater.get_cache_data", mock_get_cache_data),
         patch("updater.updater.get_current_timestamp", mock_get_current_timestamp),

--- a/deploy/tests/test_update_drones_websocket_v2.py
+++ b/deploy/tests/test_update_drones_websocket_v2.py
@@ -35,12 +35,13 @@ async def test_1():
     нема даних в memcache
     зберігання перших даних
     """
-    mock_mc = object()
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
 
     def mock_get_cache_data_side_effect(mc, key, default=None):
         mock_responses = {
             b"ws_info": get_reasons_mock(),
-            b"drones_websocket_v2": [[0, 1645674000]] * 26,
+            b"alerts_websocket_v1": [1] * 26,
         }
         return mock_responses.get(key, default)
 
@@ -49,16 +50,13 @@ async def test_1():
     mock_timestamp = 1700000000
     mock_get_current_timestamp = Mock(return_value=mock_timestamp)
 
-    mock_store_websocket_data = AsyncMock()
-
     with (
         patch("updater.updater.get_cache_data", mock_get_cache_data),
         patch("updater.updater.get_current_timestamp", mock_get_current_timestamp),
-        patch("updater.updater.store_websocket_data", mock_store_websocket_data),
     ):
 
         await update_drones_websocket_v2(mock_mc, run_once=True)
-        assert mock_get_cache_data.call_count == 2
+        assert mock_get_cache_data.call_count == 3
 
         expected_drones = [[0, 1645674000]] * 26
 
@@ -66,13 +64,7 @@ async def test_1():
         expected_drones[1] = [1, mock_timestamp]
         expected_drones[2] = [1, mock_timestamp]
 
-        expected_calls = [
-            call(mock_mc, expected_drones, [[0, 1645674000]] * 26, "drones_websocket_v2", b"drones_websocket_v2"),
-        ]
-
-        mock_store_websocket_data.assert_has_calls(expected_calls, any_order=True)
-
-        assert mock_store_websocket_data.call_count == 1
+        mock_mc.set.assert_awaited_with(b"drones_websocket_v2", json.dumps(expected_drones).encode("utf-8"))
 
 
 @pytest.mark.asyncio
@@ -82,7 +74,8 @@ async def test_2():
     є дані в memcache
     закінчення тривог, має бути актуальна дата закінчення
     """
-    mock_mc = object()
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
 
     websocket_data = [[1, 1600000000]] * 26
 
@@ -90,6 +83,7 @@ async def test_2():
         mock_responses = {
             b"ws_info": {"reasons": []},
             b"drones_websocket_v2": websocket_data,
+            b"alerts_websocket_v1": [1] * 26,
         }
         return mock_responses.get(key, default)
 
@@ -98,26 +92,17 @@ async def test_2():
     mock_timestamp = 1700000000
     mock_get_current_timestamp = Mock(return_value=mock_timestamp)
 
-    mock_store_websocket_data = AsyncMock()
-
     with (
         patch("updater.updater.get_cache_data", mock_get_cache_data),
         patch("updater.updater.get_current_timestamp", mock_get_current_timestamp),
-        patch("updater.updater.store_websocket_data", mock_store_websocket_data),
     ):
 
         await update_drones_websocket_v2(mock_mc, run_once=True)
-        assert mock_get_cache_data.call_count == 2
+        assert mock_get_cache_data.call_count == 3
 
         expected_drones = [[0, mock_timestamp]] * 26
 
-        expected_calls = [
-            call(mock_mc, expected_drones, websocket_data, "drones_websocket_v2", b"drones_websocket_v2"),
-        ]
-
-        mock_store_websocket_data.assert_has_calls(expected_calls, any_order=True)
-
-        assert mock_store_websocket_data.call_count == 1
+        mock_mc.set.assert_awaited_with(b"drones_websocket_v2", json.dumps(expected_drones).encode("utf-8"))
 
 
 @pytest.mark.asyncio
@@ -127,7 +112,8 @@ async def test_3():
     є дані в memcache
     оновлення активних тривог, дата активних не має мінятись
     """
-    mock_mc = object()
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
 
     websocket_data = [[1, 1600000000]] * 26
 
@@ -137,6 +123,7 @@ async def test_3():
                 "reasons": [{"regionId": "11", "parentRegionId": "11", "alertTypes": ["Drones", "Ballistic"]}]
             },
             b"drones_websocket_v2": websocket_data,
+            b"alerts_websocket_v1": [1] * 26,
         }
         return mock_responses.get(key, default)
 
@@ -145,27 +132,18 @@ async def test_3():
     mock_timestamp = 1700000000
     mock_get_current_timestamp = Mock(return_value=mock_timestamp)
 
-    mock_store_websocket_data = AsyncMock()
-
     with (
         patch("updater.updater.get_cache_data", mock_get_cache_data),
         patch("updater.updater.get_current_timestamp", mock_get_current_timestamp),
-        patch("updater.updater.store_websocket_data", mock_store_websocket_data),
     ):
 
         await update_drones_websocket_v2(mock_mc, run_once=True)
-        assert mock_get_cache_data.call_count == 2
+        assert mock_get_cache_data.call_count == 3
 
         expected_drones = [[0, mock_timestamp]] * 26
         expected_drones[0] = [1, 1600000000]
 
-        expected_calls = [
-            call(mock_mc, expected_drones, websocket_data, "drones_websocket_v2", b"drones_websocket_v2"),
-        ]
-
-        mock_store_websocket_data.assert_has_calls(expected_calls, any_order=True)
-
-        assert mock_store_websocket_data.call_count == 1
+        mock_mc.set.assert_awaited_with(b"drones_websocket_v2", json.dumps(expected_drones).encode("utf-8"))
 
 
 @pytest.mark.asyncio
@@ -175,7 +153,8 @@ async def test_4():
     є дані в memcache
     оновлення активних тривог, інший тип, актальних нема
     """
-    mock_mc = object()
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
 
     websocket_data = [[1, 1600000000]] * 26
 
@@ -183,6 +162,7 @@ async def test_4():
         mock_responses = {
             b"ws_info": {"reasons": [{"regionId": "11", "parentRegionId": "11", "alertTypes": ["Ballistic"]}]},
             b"drones_websocket_v2": websocket_data,
+            b"alerts_websocket_v1": [1] * 26,
         }
         return mock_responses.get(key, default)
 
@@ -191,26 +171,17 @@ async def test_4():
     mock_timestamp = 1700000000
     mock_get_current_timestamp = Mock(return_value=mock_timestamp)
 
-    mock_store_websocket_data = AsyncMock()
-
     with (
         patch("updater.updater.get_cache_data", mock_get_cache_data),
         patch("updater.updater.get_current_timestamp", mock_get_current_timestamp),
-        patch("updater.updater.store_websocket_data", mock_store_websocket_data),
     ):
 
         await update_drones_websocket_v2(mock_mc, run_once=True)
-        assert mock_get_cache_data.call_count == 2
+        assert mock_get_cache_data.call_count == 3
 
         expected_drones = [[0, mock_timestamp]] * 26
 
-        expected_calls = [
-            call(mock_mc, expected_drones, websocket_data, "drones_websocket_v2", b"drones_websocket_v2"),
-        ]
-
-        mock_store_websocket_data.assert_has_calls(expected_calls, any_order=True)
-
-        assert mock_store_websocket_data.call_count == 1
+        mock_mc.set.assert_awaited_with(b"drones_websocket_v2", json.dumps(expected_drones).encode("utf-8"))
 
 
 @pytest.mark.asyncio
@@ -220,14 +191,14 @@ async def test_5():
     є дані в memcache, нульові
     тривог нема, дані не міняються
     """
-    mock_mc = object()
-
-    websocket_data = [[0, 1645674000]] * 26
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
 
     def mock_get_cache_data_side_effect(mc, key, default=None):
         mock_responses = {
             b"ws_info": {"reasons": []},
-            b"drones_websocket_v2": websocket_data,
+            b"drones_websocket_v2": [[0, 1645674000]] * 26,
+            b"alerts_websocket_v1": [1] * 26,
         }
         return mock_responses.get(key, default)
 
@@ -236,26 +207,15 @@ async def test_5():
     mock_timestamp = 1700000000
     mock_get_current_timestamp = Mock(return_value=mock_timestamp)
 
-    mock_store_websocket_data = AsyncMock()
-
     with (
         patch("updater.updater.get_cache_data", mock_get_cache_data),
         patch("updater.updater.get_current_timestamp", mock_get_current_timestamp),
-        patch("updater.updater.store_websocket_data", mock_store_websocket_data),
     ):
 
         await update_drones_websocket_v2(mock_mc, run_once=True)
-        assert mock_get_cache_data.call_count == 2
+        assert mock_get_cache_data.call_count == 3
 
-        expected_drones = websocket_data
-
-        expected_calls = [
-            call(mock_mc, expected_drones, websocket_data, "drones_websocket_v2", b"drones_websocket_v2"),
-        ]
-
-        mock_store_websocket_data.assert_has_calls(expected_calls, any_order=True)
-
-        assert mock_store_websocket_data.call_count == 1
+        mock_mc.set.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -265,14 +225,14 @@ async def test_6():
     є дані в memcache, нульові
     є нова тривога
     """
-    mock_mc = object()
-
-    websocket_data = [[0, 1645674000]] * 26
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
 
     def mock_get_cache_data_side_effect(mc, key, default=None):
         mock_responses = {
             b"ws_info": {"reasons": [{"regionId": "13", "parentRegionId": "13", "alertTypes": ["Drones", "Missile"]}]},
-            b"drones_websocket_v2": websocket_data,
+            b"drones_websocket_v2": [[0, 1645674000]] * 26,
+            b"alerts_websocket_v1": [1] * 26,
         }
         return mock_responses.get(key, default)
 
@@ -281,127 +241,50 @@ async def test_6():
     mock_timestamp = 1700000000
     mock_get_current_timestamp = Mock(return_value=mock_timestamp)
 
-    mock_store_websocket_data = AsyncMock()
 
     with (
         patch("updater.updater.get_cache_data", mock_get_cache_data),
         patch("updater.updater.get_current_timestamp", mock_get_current_timestamp),
-        patch("updater.updater.store_websocket_data", mock_store_websocket_data),
     ):
 
         await update_drones_websocket_v2(mock_mc, run_once=True)
-        assert mock_get_cache_data.call_count == 2
+        assert mock_get_cache_data.call_count == 3
 
         expected_drones = [[0, 1645674000]] * 26
         expected_drones[1] = [1, mock_timestamp]
 
-        expected_calls = [
-            call(mock_mc, expected_drones, websocket_data, "drones_websocket_v2", b"drones_websocket_v2"),
-        ]
-
-        mock_store_websocket_data.assert_has_calls(expected_calls, any_order=True)
-
-        assert mock_store_websocket_data.call_count == 1
+        mock_mc.set.assert_awaited_with(b"drones_websocket_v2", json.dumps(expected_drones).encode("utf-8"))
 
 
-# @pytest.mark.asyncio
-# @patch("updater.updater.update_period", new=0)
-# @patch.object(datetime, "datetime")
-# async def test_1(mock_datetime):
-#     """
-#     нема даних в memcache
-#     зберігання перших даних
-#     """
-#     mock_mc = object()
-#     def mock_get_cache_data_side_effect(mc, key, default=None):
-#         mock_responses = {
-#             b"ws_info": get_reasons_mock(),
-#             b"drones_websocket_v2": [[0, 1645674000]] * 26,
-#             b"missiles_websocket_v2": [[0, 1645674000]] * 26,
-#             b"ballistic_websocket_v2": [[0, 1645674000]] * 26,
-#         }
-#         return mock_responses.get(key, default)
+@pytest.mark.asyncio
+@patch("updater.updater.update_period", new=0)
+async def test_7():
+    """
+    нема даних в memcache
+    нема тривог
+    зберігання перших даних не повинно відбутись
+    """
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
 
-#     mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"ws_info": get_reasons_mock(),
+            b"alerts_websocket_v1": [0] * 26,
+        }
+        return mock_responses.get(key, default)
 
-#     mock_timestamp = 1700000000
-#     mock_get_current_timestamp = Mock(return_value=mock_timestamp)
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
 
-#     mock_store_websocket_data = AsyncMock()
+    mock_timestamp = 1700000000
+    mock_get_current_timestamp = Mock(return_value=mock_timestamp)
 
-#     with patch("updater.updater.get_cache_data", mock_get_cache_data), \
-#          patch("updater.updater.get_current_timestamp", mock_get_current_timestamp), \
-#          patch("updater.updater.store_websocket_data", mock_store_websocket_data):
+    with (
+        patch("updater.updater.get_cache_data", mock_get_cache_data),
+        patch("updater.updater.get_current_timestamp", mock_get_current_timestamp),
+    ):
 
-#         await update_alert_reasons_websocket_v1(mock_mc, run_once=True)
-#         assert mock_get_cache_data.call_count == 4
-#         assert mock_store_websocket_data.call_count == 3
+        await update_drones_websocket_v2(mock_mc, run_once=True)
+        assert mock_get_cache_data.call_count == 3
 
-#         expected_drones = [[0, 1645674000]] * 26
-#         expected_missiles = [[0, 1645674000]] * 26
-#         expected_ballistic = [[0, 1645674000]] * 26
-
-#         expected_drones[0] = [1, mock_timestamp]
-#         expected_drones[1] = [1, mock_timestamp]
-#         expected_drones[2] = [1, mock_timestamp]
-
-#         expected_missiles[1] = [1, mock_timestamp]
-
-#         expected_ballistic[0] = [1, mock_timestamp]
-
-#         expected_calls = [
-#             call(mock_mc, expected_drones, [[0, 1645674000]] * 26, "drones_websocket_v2", b"drones_websocket_v2"),
-#             call(mock_mc, expected_missiles, [[0, 1645674000]] * 26, "missiles_websocket_v2", b"missiles_websocket_v2"),
-#             call(mock_mc, expected_ballistic, [[0, 1645674000]] * 26, "ballistic_websocket_v2", b"ballistic_websocket_v2"),
-#         ]
-
-#         mock_store_websocket_data.assert_has_calls(expected_calls, any_order=True)
-
-#         assert mock_store_websocket_data.call_count == 3
-
-# @pytest.mark.asyncio
-# @patch("updater.updater.update_period", new=0)
-# @patch.object(datetime, "datetime")
-# async def test_2(mock_datetime):
-#     """
-#     є дані в memcache
-#     закінчення тривог, має бути актуальна дата закінчення
-#     """
-#     mock_mc = object()
-#     def mock_get_cache_data_side_effect(mc, key, default=None):
-#         mock_responses = {
-#             b"ws_info": {"reasons": []},
-#             b"drones_websocket_v2": [[1, 1600000000]] * 26,
-#             b"missiles_websocket_v2": [[1, 1600000000]] * 26,
-#             b"ballistic_websocket_v2": [[1, 1600000000]] * 26,
-#         }
-#         return mock_responses.get(key, default)
-
-#     mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
-
-#     mock_timestamp = 1700000000
-#     mock_get_current_timestamp = Mock(return_value=mock_timestamp)
-
-#     mock_store_websocket_data = AsyncMock()
-
-#     with patch("updater.updater.get_cache_data", mock_get_cache_data), \
-#          patch("updater.updater.get_current_timestamp", mock_get_current_timestamp), \
-#          patch("updater.updater.store_websocket_data", mock_store_websocket_data):
-
-#         await update_alert_reasons_websocket_v1(mock_mc, run_once=True)
-#         assert mock_get_cache_data.call_count == 4
-#         assert mock_store_websocket_data.call_count == 3
-
-#         expected_drones = [[0, mock_timestamp]] * 26
-#         expected_missiles = [[0, mock_timestamp]] * 26
-#         expected_ballistic = [[0, mock_timestamp]] * 26
-
-#         expected_calls = [
-#             call(mock_mc, expected_drones, [[1, 1600000000]] * 26, "drones_websocket_v2", b"drones_websocket_v2"),
-#             call(mock_mc, expected_missiles, [[1, 1600000000]] * 26, "missiles_websocket_v2", b"missiles_websocket_v2"),
-#             call(mock_mc, expected_ballistic, [[1, 1600000000]] * 26, "ballistic_websocket_v2", b"ballistic_websocket_v2"),
-#         ]
-
-#         mock_store_websocket_data.assert_has_calls(expected_calls, any_order=True)
-
-#         assert mock_store_websocket_data.call_count == 3
+        mock_mc.set.assert_not_called()

--- a/deploy/tests/test_update_explosions_etryvoga_v1.py
+++ b/deploy/tests/test_update_explosions_etryvoga_v1.py
@@ -14,9 +14,7 @@ unix 1736935200 - 2025-01-15T10:00:00Z
 
 @pytest.mark.asyncio
 @patch("updater.updater.update_period", new=0)
-@patch("updater.updater.get_cache_data", new_callable=AsyncMock)
-@patch("updater.updater.get_etryvoga", new_callable=AsyncMock)
-async def test_1(mock_get_etryvoga, mock_get_cache_data):
+async def test_1():
     """
     нема даних для вебсокета в мемкеш
     зберігання першої тривоги
@@ -25,27 +23,33 @@ async def test_1(mock_get_etryvoga, mock_get_cache_data):
     mock_mc = AsyncMock(spec=Client)
     mock_mc.set.return_value = True
 
-    mock_get_etryvoga.return_value = {
-        "version": 1,
-        "states": {"11": {"lastUpdate": "2022-02-24T03:40:00Z"}, "13": {"lastUpdate": "2025-01-15T10:00:00Z"}},
-        "info": {
-            "last_update": "2025-01-26T19:18:55Z",
-            "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
-        },
-    }
-    mock_get_cache_data.return_value = []
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"explosions_etryvoga": {
+                "version": 1,
+                "states": {"11": {"lastUpdate": "2022-02-24T03:40:00Z"}, "13": {"lastUpdate": "2025-01-15T10:00:00Z"}},
+                "info": {
+                    "last_update": "2025-01-26T19:18:55Z",
+                    "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+                },
+            }
+        }
+        return mock_responses.get(key, default)
 
-    await update_explosions_etryvoga_v1(mock_mc, run_once=True)
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
 
-    expected_result = [1645674000, 1736935200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    mock_mc.set.assert_awaited_with(b"explosions_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_explosions_etryvoga_v1(mock_mc, run_once=True)
+
+        expected_result = [1645674000] * 26
+        expected_result[1] = 1736935200
+
+        mock_mc.set.assert_awaited_with(b"explosions_websocket_v1", json.dumps(expected_result).encode("utf-8"))
 
 
 @pytest.mark.asyncio
 @patch("updater.updater.update_period", new=0)
-@patch("updater.updater.get_cache_data", new_callable=AsyncMock)
-@patch("updater.updater.get_etryvoga", new_callable=AsyncMock)
-async def test_2(mock_get_etryvoga, mock_get_cache_data):
+async def test_2():
     """
     є дані в memcache
     апдейт часу першої тривоги
@@ -54,44 +58,26 @@ async def test_2(mock_get_etryvoga, mock_get_cache_data):
     mock_mc = AsyncMock(spec=Client)
     mock_mc.set.return_value = True
 
-    mock_get_etryvoga.return_value = {
-        "version": 1,
-        "states": {"11": {"lastUpdate": "2025-01-15T10:00:00Z"}},
-        "info": {
-            "last_update": "2025-01-26T19:18:55Z",
-            "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
-        },
-    }
-    mock_get_cache_data.return_value = [
-        1645674000,
-        1736935200,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ]
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"explosions_etryvoga": {
+                "version": 1,
+                "states": {"11": {"lastUpdate": "2025-02-24T03:40:00Z"}},
+                "info": {
+                    "last_update": "2025-02-26T19:18:55Z",
+                    "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+                },
+            },
+            b"explosions_websocket_v1": [1700000000] * 26,
+        }
+        return mock_responses.get(key, default)
 
-    await update_explosions_etryvoga_v1(mock_mc, run_once=True)
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
 
-    expected_result = [1736935200, 1736935200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    mock_mc.set.assert_awaited_with(b"explosions_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_explosions_etryvoga_v1(mock_mc, run_once=True)
+
+        expected_result = [1700000000] * 26
+        expected_result[0] = 1740368400
+
+        mock_mc.set.assert_awaited_with(b"explosions_websocket_v1", json.dumps(expected_result).encode("utf-8"))

--- a/deploy/tests/test_update_missiles_etryvoga_v1.py
+++ b/deploy/tests/test_update_missiles_etryvoga_v1.py
@@ -14,9 +14,7 @@ unix 1736935200 - 2025-01-15T10:00:00Z
 
 @pytest.mark.asyncio
 @patch("updater.updater.update_period", new=0)
-@patch("updater.updater.get_cache_data", new_callable=AsyncMock)
-@patch("updater.updater.get_etryvoga", new_callable=AsyncMock)
-async def test_1(mock_get_etryvoga, mock_get_cache_data):
+async def test_1():
     """
     нема даних для вебсокета в мемкеш
     зберігання першої тривоги
@@ -25,27 +23,33 @@ async def test_1(mock_get_etryvoga, mock_get_cache_data):
     mock_mc = AsyncMock(spec=Client)
     mock_mc.set.return_value = True
 
-    mock_get_etryvoga.return_value = {
-        "version": 1,
-        "states": {"11": {"lastUpdate": "2022-02-24T03:40:00Z"}, "13": {"lastUpdate": "2025-01-15T10:00:00Z"}},
-        "info": {
-            "last_update": "2025-01-26T19:18:55Z",
-            "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
-        },
-    }
-    mock_get_cache_data.return_value = []
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"missiles_etryvoga": {
+                "version": 1,
+                "states": {"11": {"lastUpdate": "2022-02-24T03:40:00Z"}, "13": {"lastUpdate": "2025-01-15T10:00:00Z"}},
+                "info": {
+                    "last_update": "2025-01-26T19:18:55Z",
+                    "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+                },
+            }
+        }
+        return mock_responses.get(key, default)
 
-    await update_missiles_etryvoga_v1(mock_mc, run_once=True)
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
 
-    expected_result = [1645674000, 1736935200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    mock_mc.set.assert_awaited_with(b"missiles_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_missiles_etryvoga_v1(mock_mc, run_once=True)
+
+        expected_result = [1645674000] * 26
+        expected_result[1] = 1736935200
+
+        mock_mc.set.assert_awaited_with(b"missiles_websocket_v1", json.dumps(expected_result).encode("utf-8"))
 
 
 @pytest.mark.asyncio
 @patch("updater.updater.update_period", new=0)
-@patch("updater.updater.get_cache_data", new_callable=AsyncMock)
-@patch("updater.updater.get_etryvoga", new_callable=AsyncMock)
-async def test_2(mock_get_etryvoga, mock_get_cache_data):
+async def test_2():
     """
     є дані в memcache
     апдейт часу першої тривоги
@@ -54,44 +58,28 @@ async def test_2(mock_get_etryvoga, mock_get_cache_data):
     mock_mc = AsyncMock(spec=Client)
     mock_mc.set.return_value = True
 
-    mock_get_etryvoga.return_value = {
-        "version": 1,
-        "states": {"11": {"lastUpdate": "2025-01-15T10:00:00Z"}},
-        "info": {
-            "last_update": "2025-01-26T19:18:55Z",
-            "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
-        },
-    }
-    mock_get_cache_data.return_value = [
-        1645674000,
-        1736935200,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-        0,
-    ]
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"missiles_etryvoga": {
+                "version": 1,
+                "states": {"11": {"lastUpdate": "2025-02-24T03:40:00Z"}},
+                "info": {
+                    "last_update": "2025-02-26T19:18:55Z",
+                    "last_id": "239a016a03c583633424afb5d418051b0a33a59374d0884912f8062336c09a93",
+                },
+            },
+            b"missiles_websocket_v1": [1736935200] * 26,
+            b"missiles_websocket_v2": [[0, 1645674000]] * 26,
+        }
+        return mock_responses.get(key, default)
 
-    await update_missiles_etryvoga_v1(mock_mc, run_once=True)
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
 
-    expected_result = [1736935200, 1736935200, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-    mock_mc.set.assert_awaited_with(b"missiles_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_missiles_etryvoga_v1(mock_mc, run_once=True)
+
+        expected_result = [1736935200] * 26
+        expected_result[0] = 1740368400
+
+        mock_mc.set.assert_awaited_with(b"missiles_websocket_v1", json.dumps(expected_result).encode("utf-8"))
+

--- a/deploy/tests/test_update_missiles_etryvoga_v1.py
+++ b/deploy/tests/test_update_missiles_etryvoga_v1.py
@@ -82,4 +82,3 @@ async def test_2():
         expected_result[0] = 1740368400
 
         mock_mc.set.assert_awaited_with(b"missiles_websocket_v1", json.dumps(expected_result).encode("utf-8"))
-

--- a/deploy/tests/test_update_radiation_v1.py
+++ b/deploy/tests/test_update_radiation_v1.py
@@ -1,0 +1,343 @@
+import pytest
+import json
+from unittest.mock import Mock, AsyncMock, patch, call
+from aiomcache import Client
+from updater.updater import update_radiation_websocket_v1, regions
+
+"""
+pip install pytest pytest-asyncio
+
+"""
+
+
+def get_sensors_mock(ids=None, regions=None):
+    if ids is None:
+        ids = ["11"]
+    if regions is None:
+        regions = ["Закарпатська область"]
+    data = {
+        "states": {
+            id: {
+                "sensor_id": id,
+                "sensor_name": "вулиця Батумська, 20А",
+                "latitude": "48.51388889",
+                "longitude": "35.08222222",
+                "region_name": region,
+                "city_type_name": "місто",
+                "city_name": "Дніпро",
+                "platform_name": "КП «ЦЕМ» ДОР",
+                "notes": None,
+                "url_maps": "https://www.saveecobot.com/radiation-maps#13/48.51388889/35.08222222",
+            }
+            for id, region in zip(ids, regions)
+        },
+        "info": {"last_update": "2025-01-26T21:20:30Z"},
+    }
+    return data
+
+
+def get_data_mock(ids=None, gamma_nsv_h=None, is_old=None):
+    if ids is None:
+        ids = ["11"]
+    if gamma_nsv_h is None:
+        gamma_nsv_h = [80]
+    if is_old is None:
+        is_old = [0]
+    data = {
+        "states": [
+            {"sensor_id": id, "updated_at": "2022-03-21 13:04:02", "gamma_nsv_h": gamma_nsv_h, "is_old": is_old}
+            for id, gamma_nsv_h, is_old in zip(ids, gamma_nsv_h, is_old)
+        ],
+        "info": {"last_update": "2025-01-26T21:20:30Z"},
+    }
+    return data
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period_long", new=0)
+async def test_1():
+    """
+    нема даних для вебсокета в мемкеш
+    зберігання перших даних
+    """
+
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
+
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"radiation_sensors_saveecobot": get_sensors_mock(),
+            b"radiation_data_saveecobot": get_data_mock(),
+            b"radiation_websocket_v1": [0] * 26,
+        }
+        return mock_responses.get(key, default)
+
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_radiation_websocket_v1(mock_mc, run_once=True)
+
+        expected_radiation = [0] * 26
+
+        expected_radiation[0] = 80
+
+        mock_mc.set.assert_awaited_with(b"radiation_websocket_v1", json.dumps(expected_radiation).encode("utf-8"))
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period_long", new=0)
+async def test_2():
+    """
+    нема даних для вебсокета в мемкеш
+    вітсутність даних про сенсори
+    """
+
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
+
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"radiation_sensors_saveecobot": {"states": {}, "info": {"last_update": None}},
+            b"radiation_data_saveecobot": get_data_mock(),
+        }
+        return mock_responses.get(key, default)
+
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_radiation_websocket_v1(mock_mc, run_once=True)
+
+        expected_radiation = [0] * 26
+
+        mock_mc.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period_long", new=0)
+async def test_3():
+    """
+    нема даних для вебсокета в мемкеш
+    перевірка підрахунку даних
+    """
+
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
+
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"radiation_sensors_saveecobot": get_sensors_mock(
+                ids=["11", "12", "13", "14"],
+                regions=[
+                    "Закарпатська область",
+                    "Закарпатська область",
+                    "Івано-Франківська область",
+                    "Івано-Франківська область",
+                ],
+            ),
+            b"radiation_data_saveecobot": get_data_mock(
+                ids=["11", "12", "13", "14"], gamma_nsv_h=[80, 90, 90, 80], is_old=[0, 0, 0, 0]
+            ),
+        }
+        return mock_responses.get(key, default)
+
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_radiation_websocket_v1(mock_mc, run_once=True)
+
+        expected_radiation = [0] * 26
+        expected_radiation[0] = 85
+        expected_radiation[1] = 85
+
+        mock_mc.set.assert_awaited_with(b"radiation_websocket_v1", json.dumps(expected_radiation).encode("utf-8"))
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period_long", new=0)
+async def test_4():
+    """
+    нема даних для вебсокета в мемкеш
+    перевірка підрахунку даних з неактуальними даними
+    """
+
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
+
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"radiation_sensors_saveecobot": get_sensors_mock(
+                ids=["11", "12", "13", "14"],
+                regions=[
+                    "Закарпатська область",
+                    "Закарпатська область",
+                    "Івано-Франківська область",
+                    "Івано-Франківська область",
+                ],
+            ),
+            b"radiation_data_saveecobot": get_data_mock(
+                ids=["11", "12", "13", "14"], gamma_nsv_h=[83, 90, 95, 80], is_old=[0, 1, 0, 1]
+            ),
+        }
+        return mock_responses.get(key, default)
+
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_radiation_websocket_v1(mock_mc, run_once=True)
+
+        expected_radiation = [0] * 26
+        expected_radiation[0] = 83
+        expected_radiation[1] = 95
+
+        mock_mc.set.assert_awaited_with(b"radiation_websocket_v1", json.dumps(expected_radiation).encode("utf-8"))
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period_long", new=0)
+async def test_5():
+    """
+    нема даних для вебсокета в мемкеш
+    перевірка округлення вниз
+    """
+
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
+
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"radiation_sensors_saveecobot": get_sensors_mock(
+                ids=["11", "12", "13", "14"],
+                regions=[
+                    "Закарпатська область",
+                    "Закарпатська область",
+                    "Закарпатська область",
+                    "Закарпатська область",
+                ],
+            ),
+            b"radiation_data_saveecobot": get_data_mock(
+                ids=["11", "12", "13", "14"], gamma_nsv_h=[81, 96, 92, 104], is_old=[0, 0, 0, 0]
+            ),
+        }
+        return mock_responses.get(key, default)
+
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_radiation_websocket_v1(mock_mc, run_once=True)
+
+        expected_radiation = [0] * 26
+        expected_radiation[0] = 93
+
+        mock_mc.set.assert_awaited_with(b"radiation_websocket_v1", json.dumps(expected_radiation).encode("utf-8"))
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period_long", new=0)
+async def test_6():
+    """
+    нема даних для вебсокета в мемкеш
+    перевірка округлення вгору
+    """
+
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
+
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"radiation_sensors_saveecobot": get_sensors_mock(
+                ids=["11", "12", "13", "14"],
+                regions=[
+                    "Закарпатська область",
+                    "Закарпатська область",
+                    "Закарпатська область",
+                    "Закарпатська область",
+                ],
+            ),
+            b"radiation_data_saveecobot": get_data_mock(
+                ids=["11", "12", "13", "14"], gamma_nsv_h=[81, 96, 92, 110], is_old=[0, 0, 0, 0]
+            ),
+        }
+        return mock_responses.get(key, default)
+
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_radiation_websocket_v1(mock_mc, run_once=True)
+
+        expected_radiation = [0] * 26
+        expected_radiation[0] = 95
+
+        mock_mc.set.assert_awaited_with(b"radiation_websocket_v1", json.dumps(expected_radiation).encode("utf-8"))
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period_long", new=0)
+async def test_7():
+    """
+    нема даних для вебсокета в мемкеш
+    перезберігання нових даних
+    """
+
+    mock_mc = AsyncMock(spec=Client)
+    mock_mc.set.return_value = True
+
+    def mock_get_cache_data_side_effect(mc, key, default=None):
+        mock_responses = {
+            b"radiation_sensors_saveecobot": get_sensors_mock(),
+            b"radiation_data_saveecobot": get_data_mock(),
+            b"radiation_websocket_v1": [100] * 26,
+        }
+        return mock_responses.get(key, default)
+
+    mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+    with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+        await update_radiation_websocket_v1(mock_mc, run_once=True)
+
+        expected_radiation = [0] * 26
+
+        expected_radiation[0] = 80
+
+        mock_mc.set.assert_awaited_with(b"radiation_websocket_v1", json.dumps(expected_radiation).encode("utf-8"))
+
+
+@pytest.mark.asyncio
+@patch("updater.updater.update_period_long", new=0)
+async def test_8():
+    """
+    нема даних для вебсокета в мемкеш
+    перевірка мапінгу
+    """
+
+    for region_name, region_data in regions.items():
+
+        mock_mc = AsyncMock(spec=Client)
+        mock_mc.set.return_value = True
+
+        def mock_get_cache_data_side_effect(mc, key, default=None):
+            mock_responses = {
+                b"radiation_sensors_saveecobot": get_sensors_mock(
+                    ids=["11", "12", "13", "14"],
+                    regions=[
+                        region_name,
+                        region_name,
+                        region_name,
+                        region_name,
+                    ],
+                ),
+                b"radiation_data_saveecobot": get_data_mock(
+                    ids=["11", "12", "13", "14"], gamma_nsv_h=[81, 96, 92, 110], is_old=[0, 0, 1, 0]
+                ),
+            }
+            return mock_responses.get(key, default)
+
+        mock_get_cache_data = AsyncMock(side_effect=mock_get_cache_data_side_effect)
+
+        with (patch("updater.updater.get_cache_data", mock_get_cache_data),):
+            await update_radiation_websocket_v1(mock_mc, run_once=True)
+
+            expected_radiation = [0] * 26
+
+            expected_radiation[region_data["legacy_id"]-1] = 96
+
+            mock_mc.set.assert_awaited_with(b"radiation_websocket_v1", json.dumps(expected_radiation).encode("utf-8"))

--- a/deploy/tests/test_update_radiation_v1.py
+++ b/deploy/tests/test_update_radiation_v1.py
@@ -338,6 +338,6 @@ async def test_8():
 
             expected_radiation = [0] * 26
 
-            expected_radiation[region_data["legacy_id"]-1] = 96
+            expected_radiation[region_data["legacy_id"] - 1] = 96
 
             mock_mc.set.assert_awaited_with(b"radiation_websocket_v1", json.dumps(expected_radiation).encode("utf-8"))


### PR DESCRIPTION
1) Якщо нема тривоги - не показувати перманентні дрони і ракети (саме перманентні, ті що сповіщення показуємо)
2) Якщо вже є перманентні дрони чи ракети, не показувати сповіщення (щоб не мигало кожні 2 хв. коли дрони перелітають з району в район)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Нові функції**
  - Покращено обробку сповіщень завдяки оновленому механізму перевірки, що забезпечує точніше відображення актуальних даних для користувачів.
  
- **Рефакторинг**
  - Проведено загальне впорядкування коду та оптимізацію його структури, що сприяє підвищенню стабільності роботи системи та спрощує подальшу підтримку.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->