### PR TITLE
Fix: Прибрано режим "мікроклімат", коли нема датчиків клімата

### DIFF
--- a/firmware/src/JaamFirmware.cpp
+++ b/firmware/src/JaamFirmware.cpp
@@ -3985,7 +3985,14 @@ void initDisplayModes() {
   if (!climate.isAnySensorAvailable()) {
     LOG.println("No sensors available, disabling climate sensor options");
     // remove climate sensor options from display optins list
-    DISPLAY_MODES[6].ignore = true;
+    for (int i = 0; i < DISPLAY_MODE_OPTIONS_MAX; i++) {
+      if (DISPLAY_MODES[i].id == 4) {
+        LOG.print("Display mode disabled: ");
+        LOG.println(DISPLAY_MODES[i].name);
+        DISPLAY_MODES[i].ignore = true;
+        break;
+      }
+    }
     // change display mode to "changing" if it's not available
     if (isInIgnoreList(settings.getInt(DISPLAY_MODE), DISPLAY_MODES, DISPLAY_MODE_OPTIONS_MAX)) {
       saveDisplayMode(9);

--- a/firmware/src/JaamFirmware.cpp
+++ b/firmware/src/JaamFirmware.cpp
@@ -2314,9 +2314,8 @@ void handleModes(AsyncWebServerRequest* request) {
     addCheckbox(response, "invert_display", settings.getBool(INVERT_DISPLAY), "Інвертувати дисплей (темний шрифт на світлому фоні). УВАГА - ресурс роботи дисплея суттєво зменшиться");
     addSlider(response, "display_mode_time", "Час перемикання дисплея", settings.getInt(DISPLAY_MODE_TIME), 1, 60, 1, " с.");
     response->println("Відображати в режимі \"Перемикання\":<br><br>");
+    addCheckbox(response, "toggle_mode_weather", settings.getBool(TOGGLE_MODE_WEATHER), "Погоду у домашньому регіоні");
     if (climate.isAnySensorAvailable()) {
-      
-      addCheckbox(response, "toggle_mode_weather", settings.getBool(TOGGLE_MODE_WEATHER), "Погоду у домашньому регіоні");
       if (climate.isTemperatureAvailable()) addCheckbox(response, "toggle_mode_temp", settings.getBool(TOGGLE_MODE_TEMP), "Температуру в приміщенні");
       if (climate.isHumidityAvailable()) addCheckbox(response, "toggle_mode_hum", settings.getBool(TOGGLE_MODE_HUM), "Вологість в приміщенні");
       if (climate.isPressureAvailable()) addCheckbox(response, "toggle_mode_press", settings.getBool(TOGGLE_MODE_PRESS), "Тиск");

--- a/firmware/src/JaamFirmware.cpp
+++ b/firmware/src/JaamFirmware.cpp
@@ -3983,12 +3983,15 @@ void initDisplayOptions() {
 
 void initDisplayModes() {
   if (!climate.isAnySensorAvailable()) {
+    LOG.println("No sensors available, disabling climate sensor options");
     // remove climate sensor options from display optins list
-    DISPLAY_MODES[4].ignore = true;
+    DISPLAY_MODES[6].ignore = true;
     // change display mode to "changing" if it's not available
     if (isInIgnoreList(settings.getInt(DISPLAY_MODE), DISPLAY_MODES, DISPLAY_MODE_OPTIONS_MAX)) {
       saveDisplayMode(9);
     }
+  } else {
+    LOG.println("Climate sensor is available");
   }
 }
 


### PR DESCRIPTION
при додаванні двух нових режимів в випадайку режимів екрана режим "мікроклімат" поміняв свою абсолютну позицію і став доступним при відсутності датчиків клімату

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Нові функції**
	- Додано новий чекбокс "toggle_mode_weather", який тепер завжди відображається на початку параметрів відображення, незалежно від наявності кліматичних сенсорів.
- **Рефакторинг**
	- Покращено систему повідомлень щодо доступності кліматичних сенсорів.
	- Тепер користувач отримує більш чіткий зворотний зв’язок при виявленні або відсутності сенсорів.
	- Додано логування для відключення опцій кліматичних сенсорів, якщо вони недоступні.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->